### PR TITLE
Handle wall bounces

### DIFF
--- a/Assets/Scripts/Managers/ScoreManager.cs
+++ b/Assets/Scripts/Managers/ScoreManager.cs
@@ -53,7 +53,7 @@ public class ScoreManager : MonoBehaviour
     private void UpdateScore()
     {
         float timeEfficiencyFactor = CalcTimeFactor(PlayerData.DeltaSelectionTime);
-        currentScore = Mathf.Max(minScoreAddition, ((PlayerData.PlayerDistance * distanceWeight * timeEfficiencyFactor) - jumpPenaltyWeight));
+        currentScore += Mathf.Max(minScoreAddition, ((PlayerData.DeltaPlayerDistance * distanceWeight * timeEfficiencyFactor) - jumpPenaltyWeight));
         SetScoreText();
     }
 

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -112,11 +112,11 @@ public class PlayerController : MonoBehaviour, IPlayer
                 {
                     movedLastUpdate = true;
                 }
-                else if (checkSpeed <= stopMovingTolerance && !movedLastUpdate)
+                else if (checkSpeed <= stopMovingTolerance && !movedLastUpdate && IsGrounded())
                 {
                     // Jump completed
                     PlayerData.IncrementPlayerJumps();
-                    PlayerData.SetPlayerDistance(transform.position.x);
+                    PlayerData.UpdatePlayerDistance(transform.position.x);
                     PlayerData.AddSelectionTime(deltaSelectionTime);
                     OnJumpCompleted?.Invoke();
                     NextState();

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -10,7 +10,6 @@ public class PlayerController : MonoBehaviour, IPlayer
     public PowerSelector powerSelector;
     public TimeTracker timeTracker;
     public Rigidbody2D rb;
-    public Collider2D bodyCollider;
     public PhysicsMaterial2D defaultMaterial;
     public PhysicsMaterial2D highFrictionMaterial;
 
@@ -87,7 +86,8 @@ public class PlayerController : MonoBehaviour, IPlayer
             angleSelector.StartIndicator();
         }
 
-        distanceToGround = bodyCollider.bounds.extents.y;
+        BoxCollider2D bodyCollider = GetComponent<BoxCollider2D>();
+        distanceToGround = bodyCollider.bounds.extents.y + bodyCollider.edgeRadius;
         groundCheckLayerMask = LayerMask.GetMask(Layers.WorldName);
         defaultGravity = rb.gravityScale;
     }
@@ -286,8 +286,8 @@ public class PlayerController : MonoBehaviour, IPlayer
     {
         float playerHalfWidth = distanceToGround;
         Vector3 midPos = transform.position;
-        Vector3 leftPos = new Vector3(midPos.x - playerHalfWidth, midPos.y);
-        Vector3 rightPos = new Vector3(midPos.x + playerHalfWidth, midPos.y);
+        Vector3 leftPos = new (midPos.x - playerHalfWidth, midPos.y);
+        Vector3 rightPos = new (midPos.x + playerHalfWidth, midPos.y);
 
         bool checkLeft = Physics2D.Raycast(leftPos, Vector2.down, distanceToGround + groundedRaycastOffset, groundCheckLayerMask);
         bool checkMid = Physics2D.Raycast(midPos, Vector2.down, distanceToGround + groundedRaycastOffset, groundCheckLayerMask);

--- a/Assets/Scripts/Player/PlayerData.cs
+++ b/Assets/Scripts/Player/PlayerData.cs
@@ -3,16 +3,22 @@ public static class PlayerData
     private static int playerJumps = 0;
     private static float deltaSelectionTime = 0f;
     private static float sessionSelectionTime = 0f;
+    private static float deltaPlayerDistance = 0f;
     private static float playerDistance = 0f;
 
-    public static int PlayerJumps { get { return playerJumps; } private set { } }
+    public static int PlayerJumps { get { return playerJumps; } }
     public static float DeltaSelectionTime { get { return deltaSelectionTime; } }
     public static float SessionSelectionTime {  get { return sessionSelectionTime; } }
+    public static float DeltaPlayerDistance { get { return deltaPlayerDistance; } }
     public static float PlayerDistance { get { return playerDistance; } }
 
     public static void IncrementPlayerJumps() { playerJumps++; }
     public static void AddSelectionTime(float deltaTime) { deltaSelectionTime = deltaTime; sessionSelectionTime += deltaTime; }
-    public static void SetPlayerDistance(float distance) { playerDistance = distance; }
+    public static void UpdatePlayerDistance(float distance)
+    {
+        deltaPlayerDistance = distance - playerDistance;
+        playerDistance = distance;
+    }
     public static void ResetData()
     {
         playerJumps = 0;


### PR DESCRIPTION
Behavior when hitting walls is adjusted according to the following.

1. Score only updated when the player lands on the ground. If the player hasn't landed, the selection time won't be reset until landing.
2. If the player hits a wall above ground above ground, the player gets into angle select mode so they can jump in the air. If the player hits a wall below ground, they will stay in launch state so the select arrow never appears.

A scoring bug fix was also implemented where the entire distance was considered ever time the score was updated and the score was set to a new value. Now the score is updated using only the delta distance and is incremented when changed.