### PR TITLE
Add chunk width to hazard chunks

### DIFF
--- a/Assets/HazardChunks/GapLargeChunk.asset
+++ b/Assets/HazardChunks/GapLargeChunk.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   chunks:
   - {fileID: 2746001188014870729, guid: fe4d99758b9865946b3015126acc677d, type: 3}
   chunkType: 4
+  chunkWidth: 10
   unlockDistance: 0
   maxProgression: 1500
   minWeight: 0.3

--- a/Assets/HazardChunks/GapSmallChunk.asset
+++ b/Assets/HazardChunks/GapSmallChunk.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   chunks:
   - {fileID: 2746001188014870729, guid: b3b4799e0eb18964faa8860fab61c830, type: 3}
   chunkType: 0
+  chunkWidth: 10
   unlockDistance: 0
   maxProgression: 1500
   minWeight: 0.3

--- a/Assets/HazardChunks/MovingPlatformChunk.asset
+++ b/Assets/HazardChunks/MovingPlatformChunk.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   chunks:
   - {fileID: 8193975902164587032, guid: 6abb3847c060ec94fa078af414601814, type: 3}
   chunkType: 0
+  chunkWidth: 10
   unlockDistance: 0
   maxProgression: 1500
   minWeight: 0.3

--- a/Assets/HazardChunks/SpikeCeilingChunk.asset
+++ b/Assets/HazardChunks/SpikeCeilingChunk.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   chunks:
   - {fileID: 2178422488429310053, guid: 81100700db2f4a842bcfcdc5c31744c9, type: 3}
   chunkType: 0
+  chunkWidth: 10
   unlockDistance: 0
   maxProgression: 1500
   minWeight: 0.3

--- a/Assets/HazardChunks/SpikeEdgeChunk.asset
+++ b/Assets/HazardChunks/SpikeEdgeChunk.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   chunks:
   - {fileID: 1832244546576180856, guid: 0a9b4a80799d0074a923130cc2557a61, type: 3}
   chunkType: 0
+  chunkWidth: 10
   unlockDistance: 0
   maxProgression: 1500
   minWeight: 0.3

--- a/Assets/HazardChunks/SpikeSideChunk.asset
+++ b/Assets/HazardChunks/SpikeSideChunk.asset
@@ -16,6 +16,7 @@ MonoBehaviour:
   - {fileID: 3573682836918048758, guid: 5e5bfc68184f58343a613ec58f075a88, type: 3}
   - {fileID: 1832244546576180856, guid: 2167632a8fae9294a894702ce0203f5f, type: 3}
   chunkType: 0
+  chunkWidth: 10
   unlockDistance: 0
   maxProgression: 1500
   minWeight: 0.3

--- a/Assets/HazardChunks/WallChunk.asset
+++ b/Assets/HazardChunks/WallChunk.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   chunks:
   - {fileID: 2433897062178947417, guid: 21bf562ac1cdfff42ae592c721f2c7d6, type: 3}
   chunkType: 0
+  chunkWidth: 10
   unlockDistance: 0
   maxProgression: 1500
   minWeight: 0.3

--- a/Assets/Scripts/Chunks/Managment/HazardChunk.cs
+++ b/Assets/Scripts/Chunks/Managment/HazardChunk.cs
@@ -6,6 +6,7 @@ public abstract class HazardChunk : ScriptableObject
 {
     [SerializeField] protected GameObject[] chunks;
     [SerializeField] protected ChunkType chunkType;
+    [SerializeField] protected float chunkWidth;
     [SerializeField] protected float unlockDistance;
     [SerializeField] protected float maxProgression;
     [SerializeField] protected float minWeight;
@@ -29,6 +30,8 @@ public abstract class HazardChunk : ScriptableObject
     public bool IsUnlocked() { return isUnlocked; }
 
     public float GetWeight() { return weight; }
+
+    public float GetChunkWidth() { return chunkWidth; }
 
     public void SetSelectRangeStart(float prevTotalWeight) { selectRangeStart = prevTotalWeight; }
 

--- a/Assets/Scripts/Managers/ChunkManager.cs
+++ b/Assets/Scripts/Managers/ChunkManager.cs
@@ -5,8 +5,8 @@ using UnityEngine;
 public class ChunkManager : MonoBehaviour
 {
     [Header("Basic Chunk Settings")]
-    public float chunkWidth = 10f;
     public float spawnDistance = 40f;
+    public float baseChunkWidth = 10f;
     public float chunkFloorY = -4;
     // Spawn doesn't start at -10 so there a base amount of base blocks with no hazards
     public float startSpawnPosition = 20f;
@@ -25,6 +25,7 @@ public class ChunkManager : MonoBehaviour
     public Transform player;
 
     private float nextSpawnPositionX;
+    private float currentChunkWidth;
 
     void Start()
     {
@@ -61,7 +62,7 @@ public class ChunkManager : MonoBehaviour
 
         GameObject newChunk = Instantiate(chunkPrefab, new Vector3(nextSpawnPositionX, chunkFloorY, 0), Quaternion.identity, this.transform);
 
-        nextSpawnPositionX += chunkWidth;
+        nextSpawnPositionX += currentChunkWidth;
     }
 
     private GameObject ChooseChunkType()
@@ -73,6 +74,8 @@ public class ChunkManager : MonoBehaviour
 
         if (isSafeChunk)
         {
+            // TODO: Update base chunk width selection
+            currentChunkWidth = baseChunkWidth;
             return baseChunk;
         }
         else
@@ -114,6 +117,7 @@ public class ChunkManager : MonoBehaviour
             {
                 spawnChunk = chunk.GetChunk();
                 spawnedType = chunk.GetChunkType();
+                currentChunkWidth = chunk.GetChunkWidth();
                 break;
             }
         }
@@ -128,6 +132,7 @@ public class ChunkManager : MonoBehaviour
             // DEBUG
             UnityEngine.Debug.LogWarning($"No spawn chunk was selected. TotalWeight = {totalWeight}; SpawnValue = {spawnValue}");
             lastChunkType = ChunkType.NoneOrSafe;
+            currentChunkWidth = baseChunkWidth;
             return baseChunk;
         }
     }


### PR DESCRIPTION
Add chunk width to the hazard chunks so chunks can be variable width. The base chunk width is set in the chunk manager. No changes to gameplay.